### PR TITLE
fix: Scale the ui element rect to get proper screen values

### DIFF
--- a/Packages/Control/Runtime/Elements/UIToolkit/VisualElementControlElement.cs
+++ b/Packages/Control/Runtime/Elements/UIToolkit/VisualElementControlElement.cs
@@ -22,7 +22,25 @@ namespace Control
         public override void PopulateSource(XmlElement xmlElement)
         {
             AddNameAttribute(xmlElement, sourceObject.name);
-            AddRectAttribute(xmlElement, sourceObject.worldBound);
+            AddRectAttribute(xmlElement, WorldBoundsOnScreen());
+        }
+
+        protected Rect WorldBoundsOnScreen()
+        {
+            //RuntimePanelUtils.ScreenToPanel only works on runtime
+            //Class is not accessible so we check by class name
+            if (sourceObject.panel.GetType().Name != "RuntimePanel")
+                return sourceObject.worldBound;
+
+            var oneOnPanel = RuntimePanelUtils.ScreenToPanel(sourceObject.panel, Vector2.one);
+            Vector2 scale = new Vector2(1.0f / oneOnPanel.x, 1.0f / oneOnPanel.y);
+
+            Rect worldBounds = sourceObject.worldBound;
+            var p = worldBounds.position * scale;
+            var s = worldBounds.size * scale;
+
+            var screenRect = new Rect(p, s);
+            return screenRect;
         }
 
         protected override object[] GetChildrenObjects()

--- a/Packages/Control/Tests/TransformElementTests.cs
+++ b/Packages/Control/Tests/TransformElementTests.cs
@@ -73,40 +73,31 @@ namespace Control.Tests
         [Test]
         public void GetAttributeLocalPosition_ReturnsLocalPosition()
         {
-            //Arrange
-            string expectedValue = JsonUtility.ToJson(go1.transform.localPosition);
-
             //Act
             var value = element.GetAttribute("localPosition");
 
             //Assert
-            Assert.That(value, Is.EqualTo(expectedValue));
+            Assert.That(value, Is.EqualTo(@"{""x"":1,0,""y"":2,0,""z"":3,0}"));
         }
 
         [Test]
         public void GetAttributeLocalRotation_ReturnsLocalRotation()
         {
-            //Arrange
-            string expectedValue = JsonUtility.ToJson(go1.transform.localRotation.eulerAngles);
-
             //Act
             var value = element.GetAttribute("localRotation");
 
             //Assert
-            Assert.That(value, Is.EqualTo(expectedValue));
+            Assert.That(value, Is.EqualTo(@"{""x"":90,0,""y"":315,0,""z"":0,0}"));
         }
 
         [Test]
         public void GetAttributeLocalScale_ReturnsLocalScale()
         {
-            //Arrange
-            string expectedValue = JsonUtility.ToJson(go1.transform.localScale);
-
             //Act
             var value = element.GetAttribute("localScale");
 
             //Assert
-            Assert.That(value, Is.EqualTo(expectedValue));
+            Assert.That(value, Is.EqualTo(@"{""x"":-1,0,""y"":-2,0,""z"":-3,0}"));
         }
     }
 }

--- a/Packages/Control/package.json
+++ b/Packages/Control/package.json
@@ -2,7 +2,7 @@
   "name": "com.girureta.control",
   "displayName": "Control",
   "description": "Automation driver",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "unity": "2021.2",
   "unityRelease": "1f1",
   "dependencies": {


### PR DESCRIPTION
Uses RuntimePanelUtils.ScreenToPanel to calculate the scaling factor when going from the UI element's worldBound to the screen